### PR TITLE
コンテストの説明のフォントが適用されない問題を修正

### DIFF
--- a/resources/views/contests/contest.blade.php
+++ b/resources/views/contests/contest.blade.php
@@ -2,7 +2,7 @@
 @section('title', $contest->title)
 @section('content')
 @csrf
-<p style="white-space: pre-wrap;">{{$contest->description}}></p>
+<p style="white-space: pre-wrap;">{{$contest->description}}</p>
 <h2>{{__('ui.contest.creator')}}:{{$contest->creator}}</h2>
 <br>
 <p>{{__('ui.contest.open')}} : {{$contest->start_time}}</p>

--- a/resources/views/contests/contest.blade.php
+++ b/resources/views/contests/contest.blade.php
@@ -2,7 +2,7 @@
 @section('title', $contest->title)
 @section('content')
 @csrf
-<p><pre>{{$contest->description}}</pre></p>
+<p style="white-space: pre-wrap;">{{$contest->description}}></p>
 <h2>{{__('ui.contest.creator')}}:{{$contest->creator}}</h2>
 <br>
 <p>{{__('ui.contest.open')}} : {{$contest->start_time}}</p>


### PR DESCRIPTION
`pre` tag -> `p` tag with style `white-space: pre-wrap`